### PR TITLE
Fix homepage mobile metrics grid and hero eyebrow

### DIFF
--- a/assets/css/animations.css
+++ b/assets/css/animations.css
@@ -101,19 +101,26 @@ section { background-color: transparent; }
     }
 }
 
-/* Pill badge label above hero name */
+/* Eyebrow label above hero name */
 .hero-tag {
-    display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
     color: var(--accent-gold);
-    padding: 0.35rem 0.9rem;
-    border: 1px solid rgba(217,119,6,0.3);
-    border-radius: 100px;
-    background: rgba(217,119,6,0.07);
     margin-bottom: 1.75rem;
+}
+
+.hero-tag::before {
+    content: '';
+    display: block;
+    width: 24px;
+    height: 1px;
+    background: var(--accent-gold);
+    flex-shrink: 0;
 }
 
 .hero-title {
@@ -148,35 +155,46 @@ section { background-color: transparent; }
     }
 }
 
-/* ===== Metrics Grid (separate section) ===== */
+/* ===== Metrics Strip ===== */
 .metrics-section {
     border-top: 1px solid var(--border-subtle);
     border-bottom: 1px solid var(--border-subtle);
-    padding: 0;
+    overflow: hidden;
 }
 
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1px;
-    background: var(--border-subtle);
-}
-
-@media (min-width: 768px) {
-    .stats-grid {
-        grid-template-columns: repeat(4, 1fr);
-    }
-}
-
+/* stat-box uses Bootstrap col-6 col-md-3 for reliable 2x2 → 4-col layout */
 .stat-box {
-    background: var(--bg-surface);
-    padding: 2rem 1.25rem;
+    padding: 2rem 1rem;
     text-align: center;
+    background: var(--bg-surface);
+    position: relative;
     transition: background 0.2s;
 }
 
 .stat-box:hover {
-    background: rgba(15, 26, 46, 0.95);
+    background: rgba(15, 26, 46, 0.9);
+}
+
+/* Vertical divider via ::after */
+.stat-box::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 15%; bottom: 15%;
+    width: 1px;
+    background: var(--border-subtle);
+}
+
+/* Mobile 2x2: remove right divider on even items, add bottom divider on row 1 */
+@media (max-width: 767px) {
+    .stat-box:nth-child(2n)::after { display: none; }
+    .stat-box:nth-child(1),
+    .stat-box:nth-child(2) { border-bottom: 1px solid var(--border-subtle); }
+}
+
+/* Desktop 4-col: remove divider on last item */
+@media (min-width: 768px) {
+    .stat-box:last-child::after { display: none; }
 }
 
 .stat-val {

--- a/index.html
+++ b/index.html
@@ -77,23 +77,23 @@
     </header>
 
     <!-- ============================================================
-         METRICS GRID
+         METRICS STRIP  (col-6 = 2×2 on mobile, col-md-3 = 4-col on tablet+)
     ============================================================ -->
     <div class="metrics-section">
-        <div class="stats-grid">
-            <div class="stat-box">
+        <div class="row g-0 m-0">
+            <div class="col-6 col-md-3 stat-box">
                 <span class="stat-val">3.67</span>
                 <span class="stat-desc">QPI · Director's &amp; Dean's List</span>
             </div>
-            <div class="stat-box">
+            <div class="col-6 col-md-3 stat-box">
                 <span class="stat-val">94%</span>
                 <span class="stat-desc">Process time reduction</span>
             </div>
-            <div class="stat-box">
+            <div class="col-6 col-md-3 stat-box">
                 <span class="stat-val">₱1.7M</span>
                 <span class="stat-desc">EBITDA modeled</span>
             </div>
-            <div class="stat-box">
+            <div class="col-6 col-md-3 stat-box">
                 <span class="stat-val">5+</span>
                 <span class="stat-desc">Companies served</span>
             </div>


### PR DESCRIPTION
## What changed

### Metrics strip — 2×2 mobile layout fixed
- Switched from CSS `display: grid` (conflicting with Bootstrap) to Bootstrap's `col-6 col-md-3`
- Now reliably renders as 2×2 on mobile and 4-column on tablet+
- Hairline dividers between cells via `::after` pseudo-elements

### Hero eyebrow — visible styling
- Replaced the pill badge (border/background were too low-opacity to see) with a gold line + text eyebrow, matching the `section-label` pattern used across all sections

## Test plan
- [ ] Mobile (375px): metrics shows as a clean 2×2 grid with dividers between cells
- [ ] Desktop: metrics shows as 4 equal columns in a horizontal strip
- [ ] Hero eyebrow (gold line + "MANAGEMENT ENGINEERING · ATENEO DE MANILA UNIVERSITY") is clearly visible

https://claude.ai/code/session_018oM7T5iMV7d3ces6AJrCLy

---
_Generated by [Claude Code](https://claude.ai/code/session_018oM7T5iMV7d3ces6AJrCLy)_